### PR TITLE
Update to 1.17.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,16 +29,12 @@ dependencies {
     include "de.javagl:obj:${obj_version}"
 }
 
+
 processResources {
     inputs.property "version", project.version
 
-    from(sourceSets.main.resources.srcDirs) {
-        include "fabric.mod.json"
+    filesMatching("fabric.mod.json") {
         expand "version": project.version
-    }
-
-    from(sourceSets.main.resources.srcDirs) {
-        exclude "fabric.mod.json"
     }
 }
 
@@ -60,8 +56,14 @@ task sourcesJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allSource
 }
 
+minecraft {
+    accessWidener "src/main/resources/myron.accesswidener"
+}
+
 jar {
-    from "LICENSE"
+    from("LICENSE") {
+        rename { "${it}_${project.archivesBaseName}"}
+    }
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'fabric-loom' version '0.8-SNAPSHOT'
     id 'maven-publish'
+    id 'com.github.johnrengelman.shadow' version '7.0.0'
 }
 
 sourceCompatibility = JavaVersion.VERSION_16
@@ -18,6 +19,16 @@ repositories {
     mavenLocal()
 }
 
+// Relocating a Package
+shadowJar {
+    configurations = [project.configurations.shadow]
+    relocate 'de.javagl.obj', 'myron.shaded.de.javagl.obj'
+    classifier = "shadow"
+}
+
+tasks.remapJar.dependsOn shadowJar
+(tasks.remapJar.input as FileSystemLocationProperty<? extends FileSystemLocation>).set(shadowJar.archivePath)
+
 dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
@@ -25,8 +36,7 @@ dependencies {
 
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    modImplementation "de.javagl:obj:${obj_version}"
-    include "de.javagl:obj:${obj_version}"
+    implementation(shadow("de.javagl:obj:${obj_version}"))
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id 'fabric-loom' version '0.6-SNAPSHOT'
+    id 'fabric-loom' version '0.8-SNAPSHOT'
     id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -14,7 +14,7 @@ repositories {
     jcenter()
     maven { url = "https://oss.sonatype.org/content/repositories/releases/" }
     maven { url = "https://maven.dblsaiko.net/" }
-    maven { url = "http://server.bbkr.space:8081/artifactory/libs-release/" }
+    maven { url = "https://server.bbkr.space:8081/artifactory/libs-release/" }
     mavenLocal()
 }
 
@@ -25,7 +25,7 @@ dependencies {
 
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    modCompile "de.javagl:obj:${obj_version}"
+    modImplementation "de.javagl:obj:${obj_version}"
     include "de.javagl:obj:${obj_version}"
 }
 
@@ -42,11 +42,14 @@ processResources {
     }
 }
 
-// ensure that the encoding is set to UTF-8, no matter what the system default is
-// this fixes some edge cases with special characters not displaying correctly
-// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
+    // ensure that the encoding is set to UTF-8, no matter what the system default is
+    // this fixes some edge cases with special characters not displaying correctly
+    // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
     options.encoding = "UTF-8"
+
+    // Minecraft 1.17 (21w19a) upwards uses Java 16.
+    it.options.release = 16
 }
 
 // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ yarn_mappings=1.17.1+build.14
 loader_version=0.11.6
 
 # Mod Properties
-mod_version=1.6.0
+mod_version=1.6.1
 maven_group=dev.monarkhes
 archives_base_name=myron
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-minecraft_version=1.16.4
-yarn_mappings=1.16.4+build.7
-loader_version=0.10.8
+minecraft_version=1.17.1
+yarn_mappings=1.17.1+build.14
+loader_version=0.11.6
 
 # Mod Properties
 mod_version=1.6.0
@@ -12,5 +12,5 @@ maven_group=dev.monarkhes
 archives_base_name=myron
 
 # Dependencies
-fabric_version=0.29.2+1.16
+fabric_version=0.37.0+1.17
 obj_version=0.3.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/dev/monarkhes/myron/impl/client/Myron.java
+++ b/src/main/java/dev/monarkhes/myron/impl/client/Myron.java
@@ -110,7 +110,7 @@ public class Myron implements ClientModInitializer {
         return null;
     }
 
-    private static Map<String, MyronMaterial> getMaterials(ResourceManager resourceManager, Identifier identifier, Obj obj) throws IOException {
+    public static Map<String, MyronMaterial> getMaterials(ResourceManager resourceManager, Identifier identifier, Obj obj) throws IOException {
         Map<String, MyronMaterial> materials = new LinkedHashMap<>();
 
         for (String s : obj.getMtlFileNames()) {

--- a/src/main/java/dev/monarkhes/myron/impl/client/Myron.java
+++ b/src/main/java/dev/monarkhes/myron/impl/client/Myron.java
@@ -19,10 +19,10 @@ import net.minecraft.client.render.model.ModelBakeSettings;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.client.util.SpriteIdentifier;
-import net.minecraft.client.util.math.AffineTransformation;
-import net.minecraft.client.util.math.Vector3f;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.AffineTransformation;
+import net.minecraft.util.math.Vec3f;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
@@ -36,8 +36,8 @@ import java.util.function.Function;
 
 @Environment(EnvType.CLIENT)
 public class Myron implements ClientModInitializer {
-    private final static Vector3f NONE = new Vector3f();
-    private final static Vector3f BLOCKS = new Vector3f(0.5F, 0.5F, 0.5F);
+    private final static Vec3f NONE = new Vec3f();
+    private final static Vec3f BLOCKS = new Vec3f(0.5F, 0.5F, 0.5F);
 
     public static final String MOD_ID = "myron";
     public static final Logger LOGGER = LogManager.getLogger("Myron");
@@ -171,9 +171,9 @@ public class Myron implements ClientModInitializer {
                     ? group.getTexCoord(face.getTexCoordIndex(0))
                     : null;
 
-            Vector3f pos = of(group.getVertex(face.getVertexIndex(0)));
+            Vec3f pos = of(group.getVertex(face.getVertexIndex(0)));
             pos.add(isBlock ? BLOCKS : NONE);
-            Vector3f normal = of(group.getNormal(face.getNormalIndex(0)));
+            Vec3f normal = of(group.getNormal(face.getNormalIndex(0)));
 
             rotate(settings, pos, normal);
 
@@ -244,18 +244,18 @@ public class Myron implements ClientModInitializer {
             emitter.cullFace(material.getCullDirection());
         }
 
-        boolean bl = settings.isShaded() || material.isUvLocked();
+        boolean bl = settings.isUvLocked() || material.isUvLocked();
         emitter.spriteBake(0, sprite, MutableQuadView.BAKE_NORMALIZED | (bl ? MutableQuadView.BAKE_LOCK_UV : 0));
         emitter.emit();
     }
 
     private static void vertex(QuadEmitter emitter, Obj group, ObjFace face, int vertex, ModelBakeSettings settings, boolean isBlock) {
-        Vector3f pos = of(group.getVertex(face.getVertexIndex(vertex)));
+        Vec3f pos = of(group.getVertex(face.getVertexIndex(vertex)));
 
         // Used to offset blocks
         pos.add(isBlock ? BLOCKS : NONE);
 
-        Vector3f normal = face.containsNormalIndices()
+        Vec3f normal = face.containsNormalIndices()
                 ? of(group.getNormal(face.getNormalIndex(vertex)))
                 : calculateNormal(group, face);
 
@@ -278,22 +278,22 @@ public class Myron implements ClientModInitializer {
         }
     }
 
-    private static Vector3f calculateNormal(Obj group, ObjFace face) {
-        Vector3f p1 = of(group.getVertex(face.getVertexIndex(0)));
-        Vector3f v1 = of(group.getVertex(face.getVertexIndex(1)));
-        Vector3f v2 = of(group.getVertex(face.getVertexIndex(2)));
+    private static Vec3f calculateNormal(Obj group, ObjFace face) {
+        Vec3f p1 = of(group.getVertex(face.getVertexIndex(0)));
+        Vec3f v1 = of(group.getVertex(face.getVertexIndex(1)));
+        Vec3f v2 = of(group.getVertex(face.getVertexIndex(2)));
 
         v1.subtract(p1);
         v2.subtract(p1);
 
-        return new Vector3f(
+        return new Vec3f(
                 v1.getY() * v2.getZ() - v1.getZ() * v2.getY(),
                 v1.getZ() * v2.getX() - v1.getX() * v2.getZ(),
                 v1.getX() * v2.getY() - v1.getY() * v2.getX()
         );
     }
 
-    private static void rotate(ModelBakeSettings settings, Vector3f pos, Vector3f normal) {
+    private static void rotate(ModelBakeSettings settings, Vec3f pos, Vec3f normal) {
         if (settings.getRotation() != AffineTransformation.identity()) {
             pos.add(-0.5F, -0.5F, -0.5F);
             pos.rotate(settings.getRotation().getRotation2());
@@ -303,23 +303,23 @@ public class Myron implements ClientModInitializer {
         }
     }
 
-    private static void vertex(QuadEmitter emitter, int vertex, Vector3f pos, Vector3f normal, float u, float v) {
+    private static void vertex(QuadEmitter emitter, int vertex, Vec3f pos, Vec3f normal, float u, float v) {
         emitter.pos(vertex, pos);
         emitter.normal(vertex, normal);
         emitter.sprite(vertex, 0, u, v);
     }
 
-    private static Vector3f of(FloatTuple tuple) {
-        return new Vector3f(tuple.getX(), tuple.getY(), tuple.getZ());
+    private static Vec3f of(FloatTuple tuple) {
+        return new Vec3f(tuple.getX(), tuple.getY(), tuple.getZ());
     }
 
     private static class Vertex {
-        public final Vector3f pos;
-        public final Vector3f normal;
+        public final Vec3f pos;
+        public final Vec3f normal;
         public final float u;
         public final float v;
 
-        private Vertex(Vector3f pos, Vector3f normal, float u, float v) {
+        private Vertex(Vec3f pos, Vec3f normal, float u, float v) {
             this.pos = pos;
             this.normal = normal;
             this.u = u;

--- a/src/main/java/dev/monarkhes/myron/impl/client/model/MyronUnbakedModel.java
+++ b/src/main/java/dev/monarkhes/myron/impl/client/model/MyronUnbakedModel.java
@@ -27,14 +27,16 @@ public class MyronUnbakedModel implements UnbakedModel {
     private final SpriteIdentifier sprite;
     private final ModelTransformation transform;
     private final boolean isSideLit;
+    private final boolean isBlock;
 
-    public MyronUnbakedModel(@Nullable Obj obj, @Nullable Map<String, MyronMaterial> materials, Collection<SpriteIdentifier> textureDependencies, SpriteIdentifier sprite, ModelTransformation modelTransformation, boolean isSideLit) {
+    public MyronUnbakedModel(@Nullable Obj obj, @Nullable Map<String, MyronMaterial> materials, Collection<SpriteIdentifier> textureDependencies, SpriteIdentifier sprite, ModelTransformation modelTransformation, boolean isSideLit, boolean isBlock) {
         this.obj = obj;
         this.materials = materials;
         this.textureDependencies = textureDependencies;
         this.sprite = sprite;
         this.transform = modelTransformation;
         this.isSideLit = isSideLit;
+        this.isBlock = isBlock;
     }
 
     @Override
@@ -50,7 +52,6 @@ public class MyronUnbakedModel implements UnbakedModel {
     @Override
     public @Nullable BakedModel bake(ModelLoader loader, Function<SpriteIdentifier, Sprite> textureGetter, ModelBakeSettings bakeSettings, Identifier modelId) {
         Mesh mesh;
-        boolean isBlock = modelId.getPath().startsWith("block");
 
         if (obj == null)
             // Try to load the obj (previous behavior)

--- a/src/main/java/dev/monarkhes/myron/impl/client/obj/AbstractObjLoader.java
+++ b/src/main/java/dev/monarkhes/myron/impl/client/obj/AbstractObjLoader.java
@@ -27,6 +27,8 @@ public class AbstractObjLoader {
 
     protected @Nullable UnbakedModel loadModel(
             ResourceManager resourceManager, Identifier identifier, ModelTransformation transformation, boolean isSideLit) {
+        boolean isBlock = identifier.getPath().startsWith("block");
+
         if (!identifier.getPath().endsWith(".obj")) {
             identifier = new Identifier(identifier.getNamespace(), identifier.getPath() + ".obj");
         }
@@ -55,7 +57,7 @@ public class AbstractObjLoader {
                         ? new SpriteIdentifier(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE, (material == null
                         ? materials.values().iterator().next()
                         : material).getTexture())
-                        : DEFAULT_SPRITE, transformation, isSideLit);
+                        : DEFAULT_SPRITE, transformation, isSideLit, isBlock);
             } catch (IOException e) {
                 Myron.LOGGER.warn("Failed to load model {}:\n{}", identifier, e.getMessage());
             }

--- a/src/main/java/dev/monarkhes/myron/impl/client/obj/AbstractObjLoader.java
+++ b/src/main/java/dev/monarkhes/myron/impl/client/obj/AbstractObjLoader.java
@@ -40,22 +40,7 @@ public class AbstractObjLoader {
 
                 InputStream inputStream = resourceManager.getResource(identifier).getInputStream();
                 Obj obj = ObjReader.read(inputStream);
-                Map<String, MyronMaterial> materials = new LinkedHashMap<>();
-
-                for (String s : obj.getMtlFileNames()) {
-                    String path = identifier.getPath();
-                    path = path.substring(0, path.lastIndexOf('/') + 1) + s;
-                    Identifier resource = new Identifier(identifier.getNamespace(), path);
-
-                    if (resourceManager.containsResource(resource)) {
-                        MaterialReader.read(
-                                new BufferedReader(
-                                    new InputStreamReader(resourceManager.getResource(resource).getInputStream())))
-                            .forEach(material -> materials.put(material.name, material));
-                    } else {
-                        Myron.LOGGER.warn("Texture does not exist: {}", resource);
-                    }
-                }
+                Map<String, MyronMaterial> materials = Myron.getMaterials(resourceManager, identifier, obj);
 
                 Collection<SpriteIdentifier> textureDependencies = new HashSet<>();
 
@@ -64,7 +49,9 @@ public class AbstractObjLoader {
                 }
 
                 MyronMaterial material = materials.get("sprite");
-                return new MyronUnbakedModel(textureDependencies, materials.size() > 0
+                return new MyronUnbakedModel(
+                        obj, materials,
+                        textureDependencies, materials.size() > 0
                         ? new SpriteIdentifier(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE, (material == null
                         ? materials.values().iterator().next()
                         : material).getTexture())

--- a/src/main/java/dev/monarkhes/myron/impl/client/obj/ObjLoader.java
+++ b/src/main/java/dev/monarkhes/myron/impl/client/obj/ObjLoader.java
@@ -44,7 +44,6 @@ public class ObjLoader extends AbstractObjLoader implements ModelResourceProvide
                 modelIdentifier.getNamespace(),
                 "models/item/" + modelIdentifier.getPath () + ".json");
 
-
         if (!modelIdentifier.getVariant().equals("inventory") || !this.resourceManager.containsResource(resource)) {
             return null;
         }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,9 +23,9 @@
     "myron.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.10.8",
-    "fabric": ">=0.29.0",
-    "minecraft": ">=1.16.4"
+    "fabricloader": ">=0.11.6",
+    "fabric": ">=0.37.0+1.17",
+    "minecraft": ">=1.17.1"
   },
   "breaks": {
     "foml": "*"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,5 +29,6 @@
   },
   "breaks": {
     "foml": "*"
-  }
+  },
+  "accessWidener": "myron.accesswidener"
 }

--- a/src/main/resources/myron.accesswidener
+++ b/src/main/resources/myron.accesswidener
@@ -1,0 +1,3 @@
+accessWidener v1 named
+extendable class net/minecraft/client/render/model/json/ModelTransformation$Deserializer
+extendable class net/minecraft/client/render/model/json/Transformation$Deserializer


### PR DESCRIPTION
Almost self explanatory, except that some changes were necessary:

Most importantly, when they're baked, `MyronUnbakedModel`s would try to always invoke `Myron.load()` to create and build the obj mesh. The problem with this is with `Item`/`BlockItem` models that use a `ModelIdentifier`: `Myron.load()` seems to only support absolute `Identifier`s, like `myron:models/misc/torus.obj`, but a `ModelIdentifier` gets passed to `Myron.load()`. I am not sure if this is a 1.17 change, but this prevents inventory models from working.

I made `MyronUnbakedModel` store the `Obj` and material map that was loaded in `AbstractObjLoader`, which is then directly used to build the `Mesh`. This fixes inventory obj models not rendering properly.